### PR TITLE
Expose TextReader and TextWriter methods

### DIFF
--- a/src/FlatFile.Core/Base/FlatFileEngine.cs
+++ b/src/FlatFile.Core/Base/FlatFileEngine.cs
@@ -57,6 +57,18 @@ namespace FlatFile.Core.Base
         public virtual IEnumerable<TEntity> Read<TEntity>(Stream stream) where TEntity : class, new()
         {
             var reader = new StreamReader(stream);
+            return Read<TEntity>(reader);
+        }
+
+        /// <summary>
+        /// Reads the specified text reader.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="reader">The reader.</param>
+        /// <returns>IEnumerable&lt;TEntity&gt;.</returns>
+        /// <exception cref="ParseLineException">Impossible to parse line</exception>
+        public virtual IEnumerable<TEntity> Read<TEntity>(TextReader reader) where TEntity : class, new()
+        {
             string line;
             int lineNumber = 0;
 
@@ -68,7 +80,7 @@ namespace FlatFile.Core.Base
             while ((line = reader.ReadLine()) != null)
             {
                 if (string.IsNullOrEmpty(line) || string.IsNullOrEmpty(line.Trim())) continue;
-                
+
                 bool ignoreEntry = false;
                 var entry = new TEntity();
                 try
@@ -104,7 +116,7 @@ namespace FlatFile.Core.Base
         /// Processes the header.
         /// </summary>
         /// <param name="reader">The reader.</param>
-        protected virtual void ProcessHeader(StreamReader reader)
+        protected virtual void ProcessHeader(TextReader reader)
         {
             reader.ReadLine();
         }
@@ -147,7 +159,17 @@ namespace FlatFile.Core.Base
         public virtual void Write<TEntity>(Stream stream, IEnumerable<TEntity> entries) where TEntity : class, new()
         {
             TextWriter writer = new StreamWriter(stream);
+            Write(writer, entries);
+        }
 
+        /// <summary>
+        /// Writes to the specified text writer.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="stream">The text writer.</param>
+        /// <param name="entries">The entries.</param>
+        public void Write<TEntity>(TextWriter writer, IEnumerable<TEntity> entries) where TEntity : class, new()
+        {
             this.WriteHeader(writer);
 
             int lineNumber = 0;

--- a/src/FlatFile.Core/IFlatFileEngine.cs
+++ b/src/FlatFile.Core/IFlatFileEngine.cs
@@ -17,11 +17,27 @@
         IEnumerable<TEntity> Read<TEntity>(Stream stream) where TEntity : class, new();
 
         /// <summary>
+        /// Reads from the specified text reader.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="stream">The text reader.</param>
+        /// <returns>IEnumerable&lt;TEntity&gt;.</returns>
+        IEnumerable<TEntity> Read<TEntity>(TextReader reader) where TEntity : class, new();
+
+        /// <summary>
         /// Writes to the specified stream.
         /// </summary>
         /// <typeparam name="TEntity">The type of the t entity.</typeparam>
         /// <param name="stream">The stream.</param>
         /// <param name="entries">The entries.</param>
         void Write<TEntity>(Stream stream, IEnumerable<TEntity> entries) where TEntity : class, new();
+
+        /// <summary>
+        /// Writes to the specified text writer.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="writer">The text writer.</param>
+        /// <param name="entries">The entries.</param>
+        void Write<TEntity>(TextWriter writer, IEnumerable<TEntity> entries) where TEntity : class, new();
     }
 }

--- a/src/FlatFile.Core/IFlatFileMultiEngine.cs
+++ b/src/FlatFile.Core/IFlatFileMultiEngine.cs
@@ -13,12 +13,20 @@ namespace FlatFile.Core
         /// </summary>
         /// <param name="stream">The stream.</param>
         void Read(Stream stream);
+
+        /// <summary>
+        /// Reads the specified text reader.
+        /// </summary>
+        /// <param name="stream">The text reader.</param>
+        void Read(TextReader reader);
+
         /// <summary>
         /// Gets any records of type <typeparamref name="T"/> read by <see cref="Read"/>.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns>IEnumerable&lt;T&gt;.</returns>
         IEnumerable<T> GetRecords<T>() where T : class, new();
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance has a file header.
         /// </summary>

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -137,7 +137,16 @@ namespace FlatFile.Delimited.Implementation
         /// <exception cref="ParseLineException">Impossible to parse line</exception>
         public void Read(Stream stream)
         {
-            var reader = new StreamReader(stream);
+            Read(new StreamReader(stream));
+        }
+
+        /// <summary>
+        /// Reads the specified text reader.
+        /// </summary>
+        /// <param name="stream">The text reader.</param>
+        /// <exception cref="ParseLineException">Impossible to parse line</exception>
+        public void Read(TextReader reader)
+        {
             string line;
             var lineNumber = 0;
 

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -141,7 +141,7 @@ namespace FlatFile.Delimited.Implementation
         }
 
         /// <summary>
-        /// Reads the specified text reader.
+        /// Reads from the specified text reader.
         /// </summary>
         /// <param name="stream">The text reader.</param>
         /// <exception cref="ParseLineException">Impossible to parse line</exception>

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -142,22 +142,22 @@ namespace FlatFile.FixedLength.Implementation
         }
 
         /// <summary>
-        /// Reads the specified streamReader.
+        /// Reads the specified text reader.
         /// </summary>
-        /// <param name="reader">The stream reader configured as the user wants.</param>
+        /// <param name="reader">The text reader configured as the user wants.</param>
         /// <exception cref="ParseLineException">Impossible to parse line</exception>
-        public void Read(StreamReader reader)
+        public void Read(TextReader reader)
         {
             ReadInternal(reader);
         }
 
         /// <summary>
-        /// Internal method (private) to read from streamreader instead of stream
+        /// Internal method (private) to read from a text reader instead of stream
         /// This way the client code have a way to specify encoding.
         /// </summary>
-        /// <param name="reader">The stream reader to read.</param>
+        /// <param name="reader">The text reader to read.</param>
         /// <exception cref="ParseLineException">Impossible to parse line</exception>
-        private void ReadInternal(StreamReader reader)
+        private void ReadInternal(TextReader reader)
         {
             string line;
             var lineNumber = 0;

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -142,7 +142,7 @@ namespace FlatFile.FixedLength.Implementation
         }
 
         /// <summary>
-        /// Reads the specified text reader.
+        /// Reads from the specified text reader.
         /// </summary>
         /// <param name="reader">The text reader configured as the user wants.</param>
         /// <exception cref="ParseLineException">Impossible to parse line</exception>


### PR DESCRIPTION
This pull request adds public `Read` and `Write` methods that accept `TextReader` and `TextWriter`, respectively. `Stream` is useful in many cases, but more control is also sometimes necessary; for example, when it comes to file encodings. 

I personally required this functionality to both be able to read an unusual encoding and to use a custom `StreamReader` implementation.

This fixes [#62](https://github.com/forcewake/FlatFile/issues/62).