### PR TITLE
Fix multiple empty fields for delimited files

### DIFF
--- a/src/FluentFiles.Delimited/Implementation/DelimitedLineParser.cs
+++ b/src/FluentFiles.Delimited/Implementation/DelimitedLineParser.cs
@@ -24,7 +24,7 @@ namespace FluentFiles.Delimited.Implementation
             foreach (var field in Layout.Fields)
             {
                 int nextDelimiterIndex = -1;
-                if (line.Length > linePosition + delimiterSize)
+                if (linePosition + delimiterSize <= line.Length)
                 {
                     if (hasQuotes)
                     {


### PR DESCRIPTION
Fix issue #10 concerning multiple subsequent empty fields for delimited files.