### PR TITLE
Add support for ignoring certain fixed width sections

### DIFF
--- a/src/FluentFiles.Core/Base/FieldSettingsBase.cs
+++ b/src/FluentFiles.Core/Base/FieldSettingsBase.cs
@@ -34,6 +34,11 @@ namespace FluentFiles.Core.Base
         /// The property underlying a field.
         /// </summary>
         PropertyInfo PropertyInfo { get; }
+
+        /// <summary>
+        /// A string that uniquely identifies a field within a layout.
+        /// </summary>
+        string UniqueKey { get; }
     }
 
     public abstract class FieldSettingsBase : IFieldSettingsContainer
@@ -48,6 +53,7 @@ namespace FluentFiles.Core.Base
         {
             PropertyInfo = propertyInfo;
             Type = PropertyInfo.PropertyType.Unwrap();
+            UniqueKey = $"[{propertyInfo.DeclaringType.AssemblyQualifiedName}]:{propertyInfo.Name}";
             DefaultConverter = propertyInfo.PropertyType.GetConverter();
             _getValue = ReflectionHelper.CreatePropertyGetter(propertyInfo);
             _setValue = ReflectionHelper.CreatePropertySetter(propertyInfo);
@@ -62,6 +68,7 @@ namespace FluentFiles.Core.Base
             TypeConverter = settings.TypeConverter;
         }
 
+        public string UniqueKey { get; }
         public int? Index { get; set; }
         public bool IsNullable { get; set; }
         public string NullValue { get; set; }

--- a/src/FluentFiles.Core/Base/FieldsContainer.cs
+++ b/src/FluentFiles.Core/Base/FieldsContainer.cs
@@ -8,25 +8,25 @@ namespace FluentFiles.Core.Base
     {
         private int _currentPropertyId = 0;
 
-        public override void AddOrUpdate<TKey>(TKey key, TFieldSettings settings)
+        public override void AddOrUpdate(TFieldSettings settings)
         {
             settings.Index = _currentPropertyId++;
 
-            base.AddOrUpdate(key, settings);
+            base.AddOrUpdate(settings);
         }
     }
 
     public class FieldsContainer<TFieldSettings> : IFieldsContainer<TFieldSettings>
-        where TFieldSettings : IFieldSettings
+        where TFieldSettings : IFieldSettingsContainer
     {
-        protected Dictionary<object, PropertySettingsContainer<TFieldSettings>> Fields { get; private set; }
+        protected Dictionary<string, PropertySettingsContainer<TFieldSettings>> Fields { get; private set; }
 
         public FieldsContainer()
         {
-            Fields = new Dictionary<object, PropertySettingsContainer<TFieldSettings>>();
+            Fields = new Dictionary<string, PropertySettingsContainer<TFieldSettings>>();
         }
 
-        public virtual void AddOrUpdate<TKey>(TKey key, TFieldSettings settings)
+        public virtual void AddOrUpdate(TFieldSettings settings)
         {
             var propertySettings = new PropertySettingsContainer<TFieldSettings>
             {
@@ -34,7 +34,7 @@ namespace FluentFiles.Core.Base
                 Index = settings.Index.GetValueOrDefault()
             };
 
-            Fields[key] = propertySettings;
+            Fields[settings.UniqueKey] = propertySettings;
         }
 
         public virtual IEnumerable<TFieldSettings> OrderedFields

--- a/src/FluentFiles.Core/Base/LayoutBase.cs
+++ b/src/FluentFiles.Core/Base/LayoutBase.cs
@@ -29,7 +29,7 @@ namespace FluentFiles.Core.Base
 
             var fieldSettings = builder.Build();
 
-            FieldsContainer.AddOrUpdate(property, fieldSettings);
+            FieldsContainer.AddOrUpdate(fieldSettings);
         }
 
         public override Type TargetType { get { return typeof (TTarget); } }

--- a/src/FluentFiles.Core/IFieldsContainer.cs
+++ b/src/FluentFiles.Core/IFieldsContainer.cs
@@ -6,7 +6,7 @@
     public interface IFieldsContainer<TFieldSettings>
         where TFieldSettings : IFieldSettings
     {
-        void AddOrUpdate<TKey>(TKey key, TFieldSettings settings);
+        void AddOrUpdate(TFieldSettings settings);
 
         IEnumerable<TFieldSettings> OrderedFields { get; }
     }

--- a/src/FluentFiles.Delimited.Attributes/Infrastructure/DelimitedLayoutDescriptorProvider.cs
+++ b/src/FluentFiles.Delimited.Attributes/Infrastructure/DelimitedLayoutDescriptorProvider.cs
@@ -39,7 +39,7 @@
 
                 if (settings != null)
                 {
-                    container.AddOrUpdate(p.Property, new DelimitedFieldSettings(p.Property, settings));
+                    container.AddOrUpdate(new DelimitedFieldSettings(p.Property, settings));
                 }
             }
             

--- a/src/FluentFiles.FixedLength.Attributes/IgnoreFixedLengthFieldAttribute.cs
+++ b/src/FluentFiles.FixedLength.Attributes/IgnoreFixedLengthFieldAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace FluentFiles.FixedLength.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    public sealed class IgnoreFixedLengthFieldAttribute : Attribute
+    {
+        public int Index { get; }
+        public int Length { get; }
+
+        public IgnoreFixedLengthFieldAttribute(int index, int length)
+        {
+            Index = index;
+            Length = length;
+        }
+    }
+}

--- a/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
+++ b/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
@@ -37,7 +37,7 @@ namespace FluentFiles.FixedLength.Attributes.Infrastructure
 
                 if (attribute != null)
                 {
-                    container.AddOrUpdate(p.Property, new FixedFieldSettings(p.Property, attribute));
+                    container.AddOrUpdate(new FixedFieldSettings(p.Property, attribute));
                 }
             }
 

--- a/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
+++ b/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
@@ -29,6 +29,11 @@ namespace FluentFiles.FixedLength.Attributes.Infrastructure
                     typeof(FixedLengthFileAttribute).Name));
             }
 
+            foreach (var ignored in fileMappingType.GetAttributes<IgnoreFixedLengthFieldAttribute>())
+            {
+                container.AddOrUpdate(new IgnoredFixedFieldSettings(ignored.Length) { Index = ignored.Index });
+            }
+
             var properties = fileMappingType.GetTypeDescription<FixedLengthFieldAttribute>();
 
             foreach (var p in properties)

--- a/src/FluentFiles.FixedLength/FixedFieldSettings.cs
+++ b/src/FluentFiles.FixedLength/FixedFieldSettings.cs
@@ -4,6 +4,7 @@ namespace FluentFiles.FixedLength
 {
     using System.Reflection;
     using FluentFiles.Core.Base;
+    using FluentFiles.Core.Conversion;
 
     public interface IFixedFieldSettings : IFieldSettings
     {
@@ -40,5 +41,31 @@ namespace FluentFiles.FixedLength
         public char PaddingChar { get; set; }
         public bool TruncateIfExceedFieldLength { get; set; }
         public Func<string, string> StringNormalizer { get; set; }
+    }
+
+    public class IgnoredFixedFieldSettings : IFixedFieldSettingsContainer
+    {
+        public IgnoredFixedFieldSettings(int length)
+        {
+            Length = length;
+            UniqueKey = Guid.NewGuid().ToString();
+        }
+        
+        public int? Index { get; set; }
+
+        public int Length { get; }
+        public string UniqueKey { get; }
+        public bool IsNullable { get; } = false;
+        public string NullValue { get; } = null;
+        public IValueConverter TypeConverter { get; } = null;
+        public bool PadLeft { get; } = false;
+        public char PaddingChar { get; } = default;
+        public bool TruncateIfExceedFieldLength { get; } = false;
+        public Func<string, string> StringNormalizer { get; } = null;
+        public Type Type { get; } = typeof(string);
+        public PropertyInfo PropertyInfo { get; } = null;
+
+        public object GetValueOf(object instance) => throw new NotSupportedException("Cannot use a fixed width layout with an ignored section for writing.");
+        public void SetValueOf(object instance, object value) { /* no-op */ }
     }
 }

--- a/src/FluentFiles.FixedLength/IFixedLayout.cs
+++ b/src/FluentFiles.FixedLength/IFixedLayout.cs
@@ -5,5 +5,10 @@
     public interface IFixedLayout<TTarget> :
         ILayout<TTarget, IFixedFieldSettingsContainer, IFixedFieldSettingsBuilder, IFixedLayout<TTarget>>
     {
+        /// <summary>
+        /// Ignores a fixed width section of a record.
+        /// </summary>
+        /// <param name="length">The length of the section to ignore.</param>
+        IFixedLayout<TTarget> Ignore(int length);
     }
 }

--- a/src/FluentFiles.FixedLength/Implementation/FixedLayout.cs
+++ b/src/FluentFiles.FixedLength/Implementation/FixedLayout.cs
@@ -37,5 +37,11 @@ namespace FluentFiles.FixedLength.Implementation
 
             return this;
         }
+
+        public IFixedLayout<TTarget> Ignore(int length)
+        {
+            FieldsContainer.AddOrUpdate(new IgnoredFixedFieldSettings(length));
+            return this;
+        }
     }
 }

--- a/src/FluentFiles.Tests/Core/FieldsContainerTests.cs
+++ b/src/FluentFiles.Tests/Core/FieldsContainerTests.cs
@@ -37,7 +37,7 @@ namespace FluentFiles.Tests.Core
         [Fact]
         public void OrderedFieldsShouldContainsOneItemAfterAdd()
         {
-            _fieldsContainer.AddOrUpdate(_propertyInfo, _fieldSettings);
+            _fieldsContainer.AddOrUpdate(_fieldSettings);
 
             _fieldsContainer.OrderedFields.Should().HaveCount(1);
         }
@@ -45,7 +45,7 @@ namespace FluentFiles.Tests.Core
         [Fact]
         public void AddOrUpdateShouldAssingRightId()
         {
-            _fieldsContainer.AddOrUpdate(_propertyInfo, _fieldSettings);
+            _fieldsContainer.AddOrUpdate(_fieldSettings);
 
             _fieldsContainer.OrderedFields.First().Index.Should().Be(0);
         }
@@ -53,11 +53,11 @@ namespace FluentFiles.Tests.Core
         [Fact]
         public void OrderedFieldsShouldContainsOneItemAfterUpdate()
         {
-            _fieldsContainer.AddOrUpdate(_propertyInfo, _fieldSettings);
+            _fieldsContainer.AddOrUpdate(_fieldSettings);
 
             _fieldSettings.IsNullable = true;
 
-            _fieldsContainer.AddOrUpdate(_propertyInfo, _fieldSettings);
+            _fieldsContainer.AddOrUpdate(_fieldSettings);
 
             _fieldsContainer.OrderedFields.Should().HaveCount(1);
         }
@@ -67,7 +67,7 @@ namespace FluentFiles.Tests.Core
         {
             foreach (var property in _properties)
             {
-                _fieldsContainer.AddOrUpdate(property, new FixedFieldSettings(property));
+                _fieldsContainer.AddOrUpdate(new FixedFieldSettings(property));
             }
 
             _fieldsContainer.OrderedFields.Should().HaveCount(_properties.Length);
@@ -78,7 +78,7 @@ namespace FluentFiles.Tests.Core
         {
             foreach (var property in _properties)
             {
-                _fieldsContainer.AddOrUpdate(property, new FixedFieldSettings(property));
+                _fieldsContainer.AddOrUpdate(new FixedFieldSettings(property));
             }
 
             int id = 0;

--- a/src/FluentFiles.Tests/Delimited/DelimitedAttributeMappingIntegrationTests.cs
+++ b/src/FluentFiles.Tests/Delimited/DelimitedAttributeMappingIntegrationTests.cs
@@ -56,7 +56,7 @@ namespace FluentFiles.Tests.Delimited
 
             // assign the attribute to the Foo property
             var container = new FieldsContainer<IDelimitedFieldSettingsContainer>();
-            container.AddOrUpdate(properties["Foo"], new DelimitedFieldSettings(properties["Foo"], attribute));
+            container.AddOrUpdate(new DelimitedFieldSettings(properties["Foo"], attribute));
 
             var layout = new DelimitedLayout<ConverterTestObject>(new DelimitedFieldSettingsBuilderFactory(), container);
             var engine = _fileEngineFactory.GetEngine(layout);

--- a/src/FluentFiles.Tests/FixedLength/FixedLayoutDescriptorProviderTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLayoutDescriptorProviderTests.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using FluentFiles.FixedLength;
+using FluentFiles.FixedLength.Attributes;
+using FluentFiles.FixedLength.Attributes.Infrastructure;
+using Xunit;
+
+namespace FluentFiles.Tests.FixedLength
+{
+    public class FixedLayoutDescriptorProviderTests
+    {
+        private readonly FixedLayoutDescriptorProvider _provider = new FixedLayoutDescriptorProvider();
+
+        [Fact]
+        public void ShouldProvideLayout()
+        {
+            // Act.
+            var descriptor = _provider.GetDescriptor<TestObject>();
+
+            // Assert.
+            Assert.Equal(typeof(TestObject), descriptor.TargetType);
+            descriptor.Fields.Should().BeEquivalentTo(new object[] {
+                new { Index = 1, Length = 5,  PaddingChar = '0' },
+                new { Index = 2, Length = 25, PaddingChar = ' ' },
+                new { Index = 3, Length = 7 },
+                new { Index = 4, Length = 5,  PaddingChar = '0', NullValue = "=Null"} }, c => c.ExcludingMissingMembers());
+        }
+
+        [FixedLengthFile]
+        [IgnoreFixedLengthField(3, 7)]
+        class TestObject
+        {
+            [FixedLengthField(1, 5, PaddingChar = '0')]
+            public int Id { get; set; }
+
+            [FixedLengthField(2, 25, PaddingChar = ' ', Padding = Padding.Right)]
+            public string Description { get; set; }
+
+            [FixedLengthField(4, 5, PaddingChar = '0', NullValue = "=Null")]
+            public int? NullableInt { get; set; }
+        }
+    }
+}

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthAttributeMappingIntegrationTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthAttributeMappingIntegrationTests.cs
@@ -49,7 +49,7 @@ namespace FluentFiles.Tests.FixedLength
             var properties = typeof (ConverterTestObject).GetProperties(BindingFlags.Instance | BindingFlags.Public).ToDictionary(info => info.Name);
 
             var container = new FieldsContainer<IFixedFieldSettingsContainer>();
-            container.AddOrUpdate(properties["Foo"], new FixedFieldSettings(properties["Foo"], attribute));
+            container.AddOrUpdate(new FixedFieldSettings(properties["Foo"], attribute));
 
             var descriptor = new LayoutDescriptorBase<IFixedFieldSettingsContainer>(container, typeof(ConverterTestObject)) {HasHeader = false};
 


### PR DESCRIPTION
This includes both fluent and attribute based mechanisms. An ignored section does not require mapping to a class member property.