### PR TITLE
Refactor layout descriptor providers

### DIFF
--- a/src/FluentFiles.Benchmark/FluentFilesVsFileHelpersRead.cs
+++ b/src/FluentFiles.Benchmark/FluentFilesVsFileHelpersRead.cs
@@ -15,6 +15,7 @@ using System.Text;
 
 namespace FluentFiles.Benchmark
 {
+    [InProcess]
     public class FluentFilesVsFileHelpersRead
     {
         private FileHelperEngine<FixedSampleRecord> _helperEngine;
@@ -22,7 +23,7 @@ namespace FluentFiles.Benchmark
 
         private string _records;
 
-        [Params(10, 100, 1000, 10000, 100000)]
+        [Params(10, 100, 1000, 10000)]//, 100000)]
         public int N;
 
         [GlobalSetup]

--- a/src/FluentFiles.Benchmark/FluentFilesVsFileHelpersRead.cs
+++ b/src/FluentFiles.Benchmark/FluentFilesVsFileHelpersRead.cs
@@ -15,7 +15,6 @@ using System.Text;
 
 namespace FluentFiles.Benchmark
 {
-    [InProcess]
     public class FluentFilesVsFileHelpersRead
     {
         private FileHelperEngine<FixedSampleRecord> _helperEngine;
@@ -23,7 +22,7 @@ namespace FluentFiles.Benchmark
 
         private string _records;
 
-        [Params(10, 100, 1000, 10000)]//, 100000)]
+        [Params(10, 100, 1000, 10000, 100000)]
         public int N;
 
         [GlobalSetup]

--- a/src/FluentFiles.Benchmark/Int32ConverterBenchmarks.cs
+++ b/src/FluentFiles.Benchmark/Int32ConverterBenchmarks.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace FluentFiles.Benchmark
+{
+    public class Int32ConverterBenchmarks
+    {
+        private System.ComponentModel.Int32Converter _bclConverter = new System.ComponentModel.Int32Converter();
+        private FluentFiles.Converters.Int32Converter _spannifiedConverter = new FluentFiles.Converters.Int32Converter();
+
+        private string[] items;
+
+        [Params(10, 100, 1000, 10000, 100000)]
+        public int N;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            items = Enumerable.Range(1, N).Select(n => n.ToString()).ToArray();
+        }
+
+        [Benchmark(Baseline = true)]
+        public int[] BCL()
+        {
+            return items.Select(i => _bclConverter.ConvertFromString(i)).Cast<int>().ToArray();
+        }
+
+        [Benchmark]
+        public int[] Spannified()
+        {
+            return items.Select(i => _spannifiedConverter.ConvertFromString(i, null)).Cast<int>().ToArray();
+        }
+    }
+}

--- a/src/FluentFiles.FixedLength.Attributes/FlatFileEngineFactoryExtensions.cs
+++ b/src/FluentFiles.FixedLength.Attributes/FlatFileEngineFactoryExtensions.cs
@@ -21,7 +21,7 @@ namespace FluentFiles.FixedLength.Attributes
         /// <param name="handleEntryReadError">The handle entry read error.</param>
         /// <returns>IFlatFileEngine.</returns>
         public static IFlatFileEngine GetEngine<TEntity>(
-            this IFlatFileEngineFactory<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer> engineFactory,
+            this IFlatFileEngineFactory<IFixedLengthLayoutDescriptor, IFixedFieldSettingsContainer> engineFactory,
             Func<string, Exception, bool> handleEntryReadError = null)
             where TEntity : class, new()
         {

--- a/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
+++ b/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
@@ -7,21 +7,17 @@ namespace FluentFiles.FixedLength.Attributes.Infrastructure
     using FluentFiles.Core.Attributes.Infrastructure;
     using FluentFiles.Core.Base;
 
-    public class FixedLayoutDescriptorProvider : ILayoutDescriptorProvider<IFixedFieldSettingsContainer, ILayoutDescriptor<IFixedFieldSettingsContainer>>
+    public class FixedLayoutDescriptorProvider : ILayoutDescriptorProvider<IFixedFieldSettingsContainer, IFixedLengthLayoutDescriptor>
     {
-        public ILayoutDescriptor<IFixedFieldSettingsContainer> GetDescriptor<T>()
-        {
-            return GetDescriptor(typeof(T));
-        }
+        public IFixedLengthLayoutDescriptor GetDescriptor<T>() => GetDescriptor(typeof(T));
 
-        public ILayoutDescriptor<IFixedFieldSettingsContainer> GetDescriptor(Type t)
+        public IFixedLengthLayoutDescriptor GetDescriptor(Type t)
         {
             var container = new FieldsContainer<IFixedFieldSettingsContainer>();
 
             var fileMappingType = t;
 
             var fileAttribute = fileMappingType.GetAttribute<FixedLengthFileAttribute>();
-
             if (fileAttribute == null)
             {
                 throw new NotSupportedException(string.Format("Mapping type {0} should be marked with {1} attribute",
@@ -30,20 +26,29 @@ namespace FluentFiles.FixedLength.Attributes.Infrastructure
             }
 
             var properties = fileMappingType.GetTypeDescription<FixedLengthFieldAttribute>();
-
             foreach (var p in properties)
             {
-                var attribute = p.Attributes.FirstOrDefault() as IFixedFieldSettings;
-
-                if (attribute != null)
+                var settings = p.Attributes.FirstOrDefault() as IFixedFieldSettings;
+                if (settings != null)
                 {
-                    container.AddOrUpdate(p.Property, new FixedFieldSettings(p.Property, attribute));
+                    container.AddOrUpdate(p.Property, new FixedFieldSettings(p.Property, settings));
                 }
             }
 
-            var descriptor = new LayoutDescriptorBase<IFixedFieldSettingsContainer>(container, t) {HasHeader = false};
-
+            var descriptor = new FixedLengthLayoutDescriptor(container, t, fileAttribute);
             return descriptor;
+        }
+
+        private sealed class FixedLengthLayoutDescriptor : LayoutDescriptorBase<IFixedFieldSettingsContainer>, IFixedLengthLayoutDescriptor
+        {
+            public FixedLengthLayoutDescriptor(
+                IFieldsContainer<IFixedFieldSettingsContainer> fieldsContainer,
+                Type targetType,
+                FixedLengthFileAttribute fileAttribute)
+                    : base(fieldsContainer, targetType)
+            {
+                HasHeader = fileAttribute.HasHeader;
+            }
         }
     }
 }

--- a/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
+++ b/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
@@ -25,13 +25,18 @@ namespace FluentFiles.FixedLength.Attributes.Infrastructure
                     typeof(FixedLengthFileAttribute).Name));
             }
 
+            foreach (var ignored in fileMappingType.GetAttributes<IgnoreFixedLengthFieldAttribute>())
+            {
+                container.AddOrUpdate(new IgnoredFixedFieldSettings(ignored.Length) { Index = ignored.Index });
+            }
+
             var properties = fileMappingType.GetTypeDescription<FixedLengthFieldAttribute>();
             foreach (var p in properties)
             {
                 var settings = p.Attributes.FirstOrDefault() as IFixedFieldSettings;
                 if (settings != null)
                 {
-                    container.AddOrUpdate(p.Property, new FixedFieldSettings(p.Property, settings));
+                    container.AddOrUpdate(new FixedFieldSettings(p.Property, settings));
                 }
             }
 

--- a/src/FluentFiles.FixedLength/IFixedLayout.cs
+++ b/src/FluentFiles.FixedLength/IFixedLayout.cs
@@ -3,6 +3,7 @@
     using FluentFiles.Core;
 
     public interface IFixedLayout<TTarget> :
+        IFixedLengthLayoutDescriptor,
         ILayout<TTarget, IFixedFieldSettingsContainer, IFixedFieldSettingsBuilder, IFixedLayout<TTarget>>
     {
     }

--- a/src/FluentFiles.FixedLength/IFixedLengthLayoutDescriptor.cs
+++ b/src/FluentFiles.FixedLength/IFixedLengthLayoutDescriptor.cs
@@ -1,0 +1,7 @@
+﻿using FluentFiles.Core;
+namespace FluentFiles.FixedLength
+{
+    public interface IFixedLengthLayoutDescriptor : ILayoutDescriptor<IFixedFieldSettingsContainer>
+    {
+    }
+}

--- a/src/FluentFiles.FixedLength/IFixedLengthLineBuilderFactory.cs
+++ b/src/FluentFiles.FixedLength/IFixedLengthLineBuilderFactory.cs
@@ -3,7 +3,7 @@ namespace FluentFiles.FixedLength
     using FluentFiles.Core;
 
     public interface IFixedLengthLineBuilderFactory :
-        ILineBuilderFactory<IFixedLengthLineBuilder, ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>
+        ILineBuilderFactory<IFixedLengthLineBuilder, IFixedLengthLayoutDescriptor, IFixedFieldSettingsContainer>
     {
     }
 }

--- a/src/FluentFiles.FixedLength/IFixedLengthLineParserFactory.cs
+++ b/src/FluentFiles.FixedLength/IFixedLengthLineParserFactory.cs
@@ -9,7 +9,7 @@ namespace FluentFiles.FixedLength
     /// Interface IFixedLengthLineParserFactory
     /// </summary>
     public interface IFixedLengthLineParserFactory :
-        ILineParserFactory<IFixedLengthLineParser, ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>
+        ILineParserFactory<IFixedLengthLineParser, IFixedLengthLayoutDescriptor, IFixedFieldSettingsContainer>
     {
         /// <summary>
         /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetType" />.

--- a/src/FluentFiles.FixedLength/Implementation/FixedLengthFileEngine.cs
+++ b/src/FluentFiles.FixedLength/Implementation/FixedLengthFileEngine.cs
@@ -7,7 +7,7 @@ namespace FluentFiles.FixedLength.Implementation
     /// <summary>
     /// Class FixedLengthFileEngine.
     /// </summary>
-    public class FixedLengthFileEngine : FlatFileEngine<IFixedFieldSettingsContainer, ILayoutDescriptor<IFixedFieldSettingsContainer>>
+    public class FixedLengthFileEngine : FlatFileEngine<IFixedFieldSettingsContainer, IFixedLengthLayoutDescriptor>
     {
         /// <summary>
         /// The line builder factory
@@ -20,7 +20,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// <summary>
         /// The layout descriptor
         /// </summary>
-        private readonly ILayoutDescriptor<IFixedFieldSettingsContainer> layoutDescriptor;
+        private readonly IFixedLengthLayoutDescriptor layoutDescriptor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FixedLengthFileEngine"/> class.
@@ -30,7 +30,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// <param name="lineParserFactory">The line parser factory.</param>
         /// <param name="handleEntryReadError">The handle entry read error.</param>
         internal FixedLengthFileEngine(
-            ILayoutDescriptor<IFixedFieldSettingsContainer> layoutDescriptor,
+            IFixedLengthLayoutDescriptor layoutDescriptor,
             IFixedLengthLineBuilderFactory lineBuilderFactory,
             IFixedLengthLineParserFactory lineParserFactory,
             Func<FlatFileErrorContext, bool> handleEntryReadError = null) : base(handleEntryReadError)
@@ -62,7 +62,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// Gets the layout descriptor.
         /// </summary>
         /// <value>The layout descriptor.</value>
-        protected override ILayoutDescriptor<IFixedFieldSettingsContainer> LayoutDescriptor
+        protected override IFixedLengthLayoutDescriptor LayoutDescriptor
         {
             get { return layoutDescriptor; }
         }

--- a/src/FluentFiles.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
+++ b/src/FluentFiles.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
@@ -9,7 +9,7 @@ namespace FluentFiles.FixedLength.Implementation
     /// <summary>
     /// Class FixedLengthFileEngineFactory.
     /// </summary>
-    public class FixedLengthFileEngineFactory : IFlatFileEngineFactory<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>
+    public class FixedLengthFileEngineFactory : IFlatFileEngineFactory<IFixedLengthLayoutDescriptor, IFixedFieldSettingsContainer>
     {
         readonly FixedLengthLineParserFactory lineParserFactory = new FixedLengthLineParserFactory();
 
@@ -42,7 +42,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// <param name="handleEntryReadError">The handle entry read error func.</param>
         /// <returns>IFlatFileEngine.</returns>
         public IFlatFileEngine GetEngine(
-            ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor,
+            IFixedLengthLayoutDescriptor descriptor,
             Func<string, Exception, bool> handleEntryReadError = null)
         {
             return new FixedLengthFileEngine(
@@ -61,7 +61,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// <param name="handleEntryReadError">The handle entry read error func.</param>
         /// <returns>IFlatFileEngine.</returns>
         public IFlatFileEngine GetEngine(
-            ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor,
+            IFixedLengthLayoutDescriptor descriptor,
             Func<FlatFileErrorContext, bool> handleEntryReadError)
         {
             return new FixedLengthFileEngine(
@@ -80,7 +80,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// <param name="masterDetailTracker">Determines how master-detail record relationships are handled.</param>
         /// <returns>IFlatFileMultiEngine.</returns>
         public IFlatFileMultiEngine GetEngine(
-            IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
+            IEnumerable<IFixedLengthLayoutDescriptor> layoutDescriptors,
             Func<string, int, Type> typeSelectorFunc,
             Func<string, Exception, bool> handleEntryReadError = null,
             IMasterDetailTracker masterDetailTracker = null)
@@ -105,7 +105,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// <param name="masterDetailTracker">Determines how master-detail record relationships are handled.</param>
         /// <returns>IFlatFileMultiEngine.</returns>
         public IFlatFileMultiEngine GetEngine(
-            IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
+            IEnumerable<IFixedLengthLayoutDescriptor> layoutDescriptors,
             Func<string, int, Type> typeSelectorFunc,
             Func<FlatFileErrorContext, bool> handleEntryReadError,
             IMasterDetailTracker masterDetailTracker = null)

--- a/src/FluentFiles.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FluentFiles.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -21,7 +21,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// <summary>
         /// The layout descriptors for this engine
         /// </summary>
-        readonly Dictionary<Type, ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors;
+        readonly Dictionary<Type, IFixedLengthLayoutDescriptor> layoutDescriptors;
         /// <summary>
         /// The line builder factory
         /// </summary>
@@ -54,7 +54,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// <param name="handleEntryReadError">The handle entry read error.</param>
         /// <exception cref="System.ArgumentNullException">typeSelectorFunc</exception>
         internal FixedLengthFileMultiEngine(
-            IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
+            IEnumerable<IFixedLengthLayoutDescriptor> layoutDescriptors,
             Func<string, int, Type> typeSelectorFunc,
             IFixedLengthLineBuilderFactory lineBuilderFactory,
             IFixedLengthLineParserFactory lineParserFactory,
@@ -63,7 +63,7 @@ namespace FluentFiles.FixedLength.Implementation
         {
             if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");
             this.layoutDescriptors = layoutDescriptors.Select(ld => new FixedLengthImmutableLayoutDescriptor(ld))
-                                                      .Cast<ILayoutDescriptor<IFixedFieldSettingsContainer>>()
+                                                      .Cast<IFixedLengthLayoutDescriptor>()
                                                       .ToDictionary(ld => ld.TargetType, ld => ld);
             results = new Dictionary<Type, ArrayList>(this.layoutDescriptors.Count());
             foreach (var descriptor in this.layoutDescriptors)

--- a/src/FluentFiles.FixedLength/Implementation/FixedLengthImmutableLayoutDescriptor.cs
+++ b/src/FluentFiles.FixedLength/Implementation/FixedLengthImmutableLayoutDescriptor.cs
@@ -1,11 +1,10 @@
-﻿using FluentFiles.Core;
-using FluentFiles.Core.Base;
+﻿using FluentFiles.Core.Base;
 
 namespace FluentFiles.FixedLength.Implementation
 {
-    public sealed class FixedLengthImmutableLayoutDescriptor : ImmutableLayoutDescriptor<IFixedFieldSettingsContainer>
+    public sealed class FixedLengthImmutableLayoutDescriptor : ImmutableLayoutDescriptor<IFixedFieldSettingsContainer>, IFixedLengthLayoutDescriptor
     {
-        public FixedLengthImmutableLayoutDescriptor(ILayoutDescriptor<IFixedFieldSettingsContainer> existing)
+        public FixedLengthImmutableLayoutDescriptor(IFixedLengthLayoutDescriptor existing)
             : base(existing)
         {
         }

--- a/src/FluentFiles.FixedLength/Implementation/FixedLengthLineBuilder.cs
+++ b/src/FluentFiles.FixedLength/Implementation/FixedLengthLineBuilder.cs
@@ -11,7 +11,7 @@ namespace FluentFiles.FixedLength.Implementation
     {
         private readonly Lazy<int> _totalLength;
 
-        public FixedLengthLineBuilder(ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor)
+        public FixedLengthLineBuilder(IFixedLengthLayoutDescriptor descriptor)
             : base(descriptor)
         {
             _totalLength = new Lazy<int>(() => descriptor.Fields.Sum(f => f.Length));

--- a/src/FluentFiles.FixedLength/Implementation/FixedLengthLineBuilderFactory.cs
+++ b/src/FluentFiles.FixedLength/Implementation/FixedLengthLineBuilderFactory.cs
@@ -1,10 +1,8 @@
 namespace FluentFiles.FixedLength.Implementation
 {
-    using FluentFiles.Core;
-
     public class FixedLengthLineBuilderFactory : IFixedLengthLineBuilderFactory
     {
-        public IFixedLengthLineBuilder GetBuilder(ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor)
+        public IFixedLengthLineBuilder GetBuilder(IFixedLengthLayoutDescriptor descriptor)
         {
             return new FixedLengthLineBuilder(descriptor);
         }

--- a/src/FluentFiles.FixedLength/Implementation/FixedLengthLineParserFactory.cs
+++ b/src/FluentFiles.FixedLength/Implementation/FixedLengthLineParserFactory.cs
@@ -36,7 +36,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// Initializes a new instance of the <see cref="FixedLengthLineParserFactory"/> class.
         /// </summary>
         /// <param name="lineParserRegistry">The line parser registry.</param>
-        public FixedLengthLineParserFactory(IDictionary<Type, ILayoutDescriptor<IFixedFieldSettingsContainer>> lineParserRegistry)
+        public FixedLengthLineParserFactory(IDictionary<Type, IFixedLengthLayoutDescriptor> lineParserRegistry)
         {
             this.lineParserRegistry = lineParserRegistry.ToDictionary(descriptor => descriptor.Key, descriptor => descriptor.Value.TargetType);
         }
@@ -46,7 +46,7 @@ namespace FluentFiles.FixedLength.Implementation
         /// </summary>
         /// <param name="descriptor">The descriptor.</param>
         /// <returns>IFixedLengthLineParser.</returns>
-        public IFixedLengthLineParser GetParser(ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor)
+        public IFixedLengthLineParser GetParser(IFixedLengthLayoutDescriptor descriptor)
         {
             if (descriptor == null) throw new ArgumentNullException(nameof(descriptor));
 

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthAttributeMappingIntegrationTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthAttributeMappingIntegrationTests.cs
@@ -17,7 +17,7 @@ namespace FluentFiles.Tests.FixedLength
 {
     public class FixedLengthAttributeMappingIntegrationTests : FixedLengthIntegrationTests
     {
-        readonly IFlatFileEngineFactory<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer> fileEngineFactory;
+        readonly IFlatFileEngineFactory<IFixedLengthLayoutDescriptor, IFixedFieldSettingsContainer> fileEngineFactory;
 
         class ConverterTestObject
         {
@@ -51,7 +51,7 @@ namespace FluentFiles.Tests.FixedLength
             var container = new FieldsContainer<IFixedFieldSettingsContainer>();
             container.AddOrUpdate(properties["Foo"], new FixedFieldSettings(properties["Foo"], attribute));
 
-            var descriptor = new LayoutDescriptorBase<IFixedFieldSettingsContainer>(container, typeof(ConverterTestObject)) {HasHeader = false};
+            var descriptor = new FixedLayout<ConverterTestObject>(new FixedFieldSettingsBuilderFactory(), container) {HasHeader = false};
 
             var engine = fileEngineFactory.GetEngine(descriptor);
 

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
@@ -14,7 +14,7 @@ namespace FluentFiles.Tests.FixedLength
 {
     public class FixedLengthErrorHandlingTests
     {
-        private ILayoutDescriptor<IFixedFieldSettingsContainer> layout;
+        private IFixedLengthLayoutDescriptor layout;
         readonly IFixedLengthLineParserFactory lineParserFactory;
         readonly IList<FlatFileErrorContext> errorContexts = new List<FlatFileErrorContext>();
 
@@ -25,7 +25,7 @@ STest Description    00044";
 
         public FixedLengthErrorHandlingTests()
         {
-            layout = A.Fake<ILayoutDescriptor<IFixedFieldSettingsContainer>>();
+            layout = A.Fake<IFixedLengthLayoutDescriptor>();
             A.CallTo(() => layout.TargetType).Returns(typeof(Record));
             A.CallTo(() => layout.InstanceFactory).Returns(() => new Record());
 

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthMasterDetailCustomTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthMasterDetailCustomTests.cs
@@ -109,7 +109,7 @@ D20150512Standalone                     ";
 
         public FixedLengthMasterDetailCustomTests()
         {
-            var layouts = new List<ILayoutDescriptor<IFixedFieldSettingsContainer>>
+            var layouts = new List<IFixedLengthLayoutDescriptor>
             {
                 new HeaderLayout(),
                 new HeaderContinuationLayout(),

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthMasterDetailTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthMasterDetailTests.cs
@@ -99,7 +99,7 @@ D20150512Standalone                     ";
 
         public FixedLengthMasterDetailTests()
         {
-            var layouts = new List<ILayoutDescriptor<IFixedFieldSettingsContainer>>
+            var layouts = new List<IFixedLengthLayoutDescriptor>
             {
                 new HeaderLayout(),
                 new HeaderContinuationLayout(),

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthMultiEngineTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthMultiEngineTests.cs
@@ -98,7 +98,7 @@ D20150323Another Description ";
 
         public FixedLengthMultiEngineTests()
         {
-            var layouts = new List<ILayoutDescriptor<IFixedFieldSettingsContainer>> {new Record1Layout(), new Record2Layout()};
+            var layouts = new List<IFixedLengthLayoutDescriptor> {new Record1Layout(), new Record2Layout()};
             engine = new FixedLengthFileMultiEngine(layouts,
                                                     (s, i) =>
                                                     {

--- a/src/FluentFiles.Tests/FluentFiles.Tests.csproj
+++ b/src/FluentFiles.Tests/FluentFiles.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
- Introduced IFixedLengthLayoutDescriptor extending ILayoutDescriptor<T>. It is initially memberless but it matches Delimited and allows for extension.
- Replaced generic reflection occurring in layout descriptor providers with simple classes.