### PR TITLE
Add field conversion context.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,28 @@
-# ChangeLog / ReleaseNotes 
+# Changelog
 
-## Version 0.2.23
+## Version 1.0.0
 
-* Fixed csv tag in the nuget packages.
-* Refactored psake with adding release notes to nuget.
+### New Features
+- Support .NET Core and target .NET Standard.
+
+- Expose an extensibility point for customizing how master/detail records are handled through the interface 
+  `IMasterDetailStrategy`.
+
+- Provide a new value converter mechanism, `IFieldValueConverter`, to replace `ITypeConverter`
+  and expose more information such as the `PropertyInfo` of the property being used.
+
+- Use field value converters when building lines.
+
+- Provide field builder methods (`WithConversionFromString`, `WithConversionToString`) that accept 
+  delegates for performing field value conversion.
+
+- Provide fixed length field builder methods (`SkipWhile`, `TakeUntil`) for advanced field value processing.
+
+- [#41](https://github.com/forcewake/FlatFile/issues/41), [#67](https://github.com/forcewake/FlatFile/issues/67) Enable capability to designate that certain sections of fixed length files should be ignored.
+
+- [#63](https://github.com/forcewake/FlatFile/issues/62) Expose `Read` and `Write` file engine methods that 
+  accept `TextReader` and `TextWriter`, respectively.
+
+
+### Bug Fixes
+- [#80](https://github.com/forcewake/FlatFile/issues/80) Problem parsing consecutive empty fields in delimited files.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@
 os: Visual Studio 2017
 
 environment:  
-  major: 0
-  minor: 3
+  major: 1
+  minor: 0
   patch: 0
 
 

--- a/src/FluentFiles.Benchmark/Converters/CsvHelperTypeConverterForCustomType.cs
+++ b/src/FluentFiles.Benchmark/Converters/CsvHelperTypeConverterForCustomType.cs
@@ -5,6 +5,7 @@ namespace FluentFiles.Benchmark.Converters
     using CsvHelper.Configuration;
     using System.Reflection;
     using CsvHelperTypeConversion = CsvHelper.TypeConversion;
+    using FluentFiles.Core.Conversion;
 
     public class CsvHelperTypeConverterForCustomType : CsvHelperTypeConversion.ITypeConverter
     {
@@ -17,12 +18,12 @@ namespace FluentFiles.Benchmark.Converters
 
         public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
         {
-            return converter.ConvertToString(value, (PropertyInfo)memberMapData.Member);
+            return converter.ConvertToString(new FieldSerializationContext(value, (PropertyInfo)memberMapData.Member));
         }
 
         public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            return converter.ConvertFromString(text.AsSpan(), (PropertyInfo)memberMapData.Member);
+            return converter.ConvertFromString(new FieldDeserializationContext(text.AsSpan(), (PropertyInfo)memberMapData.Member));
         }
     }
 }

--- a/src/FluentFiles.Benchmark/Converters/FlatFileTypeConverterForCustomType.cs
+++ b/src/FluentFiles.Benchmark/Converters/FlatFileTypeConverterForCustomType.cs
@@ -1,17 +1,15 @@
 namespace FluentFiles.Benchmark.Converters
 {
-    using System;
-    using System.Reflection;
     using FluentFiles.Benchmark.Entities;
     using FluentFiles.Core.Conversion;
     using FluentFiles.Core.Extensions;
 
     public class FlatFileConverterForCustomType : ConverterBase<CustomType>
     {
-        protected override CustomType ConvertFrom(ReadOnlySpan<char> source, PropertyInfo targetProperty)
+        protected override CustomType ConvertFrom(in FieldDeserializationContext context)
         {
             var obj = new CustomType();
-            var values = source.Split('|').GetEnumerator();
+            var values = context.Source.Split('|').GetEnumerator();
 
             values.MoveNext();
             obj.First = int.Parse(values.Current);
@@ -25,9 +23,9 @@ namespace FluentFiles.Benchmark.Converters
             return obj;
         }
 
-        protected override string ConvertTo(CustomType source, PropertyInfo sourceProperty)
+        protected override string ConvertTo(in FieldSerializationContext<CustomType> context)
         {
-            return string.Format("{0}|{1}|{2}", source.First, source.Second, source.Third);
+            return string.Format("{0}|{1}|{2}", context.Source.First, context.Source.Second, context.Source.Third);
         }
     }
 }

--- a/src/FluentFiles.Benchmark/Int32ConverterBenchmarks.cs
+++ b/src/FluentFiles.Benchmark/Int32ConverterBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using BenchmarkDotNet.Attributes;
+using FluentFiles.Core.Conversion;
 
 namespace FluentFiles.Benchmark
 {
@@ -28,7 +29,7 @@ namespace FluentFiles.Benchmark
         [Benchmark]
         public int[] Spannified()
         {
-            return items.Select(i => _spannifiedConverter.ConvertFromString(i, null)).Cast<int>().ToArray();
+            return items.Select(i => _spannifiedConverter.ConvertFromString(new FieldDeserializationContext(i, null))).Cast<int>().ToArray();
         }
     }
 }

--- a/src/FluentFiles.Converters/ByteConverter.cs
+++ b/src/FluentFiles.Converters/ByteConverter.cs
@@ -6,7 +6,7 @@ namespace FluentFiles.Converters
 {
     public sealed class ByteConverter : NumberConverterBase<byte>
     {
-        protected override byte ConvertFromString(ReadOnlySpan<char> source, NumberFormatInfo format) =>
+        protected override byte ConvertFromString(in ReadOnlySpan<char> source, NumberFormatInfo format) =>
             byte.Parse(source, provider: format);
 
         protected override string ConvertToString(byte value, NumberFormatInfo format) =>

--- a/src/FluentFiles.Converters/CharConverter.cs
+++ b/src/FluentFiles.Converters/CharConverter.cs
@@ -1,28 +1,28 @@
 ﻿using FluentFiles.Core.Conversion;
 using System;
-using System.Reflection;
 
 namespace FluentFiles.Converters
 {
     public sealed class CharConverter : ConverterBase<char>
     {
-        protected override char ConvertFrom(ReadOnlySpan<char> source, PropertyInfo targetProperty)
+        protected override char ConvertFrom(in FieldDeserializationContext context)
         {
-            if (source.Length > 1)
-                source = source.Trim();
+            var trimmed = context.Source;
+            if (trimmed.Length > 1)
+                trimmed = trimmed.Trim();
 
-            if (source.Length > 0)
-                return source[0];
+            if (trimmed.Length > 0)
+                return trimmed[0];
 
             return char.MinValue;
         }
 
-        protected override string ConvertTo(char source, PropertyInfo sourceProperty)
+        protected override string ConvertTo(in FieldSerializationContext<char> context)
         {
-            if (source == char.MinValue)
+            if (context.Source == char.MinValue)
                 return string.Empty;
 
-            return new string(source, 1);
+            return new string(context.Source, 1);
         }
     }
 }

--- a/src/FluentFiles.Converters/DecimalConverter.cs
+++ b/src/FluentFiles.Converters/DecimalConverter.cs
@@ -6,7 +6,7 @@ namespace FluentFiles.Converters
 {
     public sealed class DecimalConverter : NumberConverterBase<decimal>
     {
-        protected override decimal ConvertFromString(ReadOnlySpan<char> source, NumberFormatInfo format) =>
+        protected override decimal ConvertFromString(in ReadOnlySpan<char> source, NumberFormatInfo format) =>
             decimal.Parse(source, NumberStyles.Float, provider: format);
 
         protected override string ConvertToString(decimal value, NumberFormatInfo format) =>

--- a/src/FluentFiles.Converters/DoubleConverter.cs
+++ b/src/FluentFiles.Converters/DoubleConverter.cs
@@ -6,7 +6,7 @@ namespace FluentFiles.Converters
 {
     public sealed class DoubleConverter : NumberConverterBase<double>
     {
-        protected override double ConvertFromString(ReadOnlySpan<char> source, NumberFormatInfo format) =>
+        protected override double ConvertFromString(in ReadOnlySpan<char> source, NumberFormatInfo format) =>
             double.Parse(source, provider: format);
 
         protected override string ConvertToString(double value, NumberFormatInfo format) =>

--- a/src/FluentFiles.Converters/GuidConverter.cs
+++ b/src/FluentFiles.Converters/GuidConverter.cs
@@ -1,15 +1,14 @@
 ﻿using FluentFiles.Core.Conversion;
 using System;
-using System.Reflection;
 
 namespace FluentFiles.Converters
 {
     public sealed class GuidConverter : ConverterBase<Guid>
     {
-        protected override Guid ConvertFrom(ReadOnlySpan<char> source, PropertyInfo targetProperty) =>
-            Guid.Parse(source.Trim());
+        protected override Guid ConvertFrom(in FieldDeserializationContext context) =>
+            Guid.Parse(context.Source.Trim());
 
-        protected override string ConvertTo(Guid source, PropertyInfo sourceProperty) =>
-            source.ToString();
+        protected override string ConvertTo(in FieldSerializationContext<Guid> context) =>
+            context.Source.ToString();
     }
 }

--- a/src/FluentFiles.Converters/Int16Converter.cs
+++ b/src/FluentFiles.Converters/Int16Converter.cs
@@ -6,7 +6,7 @@ namespace FluentFiles.Converters
 {
     public sealed class Int16Converter : NumberConverterBase<short>
     {
-        protected override short ConvertFromString(ReadOnlySpan<char> source, NumberFormatInfo format) =>
+        protected override short ConvertFromString(in ReadOnlySpan<char> source, NumberFormatInfo format) =>
             short.Parse(source, provider: format);
 
         protected override string ConvertToString(short value, NumberFormatInfo format) =>

--- a/src/FluentFiles.Converters/Int32Converter.cs
+++ b/src/FluentFiles.Converters/Int32Converter.cs
@@ -6,7 +6,7 @@ namespace FluentFiles.Converters
 {
     public sealed class Int32Converter : NumberConverterBase<int>
     {
-        protected override int ConvertFromString(ReadOnlySpan<char> source, NumberFormatInfo format) => 
+        protected override int ConvertFromString(in ReadOnlySpan<char> source, NumberFormatInfo format) => 
             int.Parse(source, provider: format);
 
         protected override string ConvertToString(int value, NumberFormatInfo format) => 

--- a/src/FluentFiles.Converters/Int64Converter.cs
+++ b/src/FluentFiles.Converters/Int64Converter.cs
@@ -6,7 +6,7 @@ namespace FluentFiles.Converters
 {
     public sealed class Int64Converter : NumberConverterBase<long>
     {
-        protected override long ConvertFromString(ReadOnlySpan<char> source, NumberFormatInfo format) =>
+        protected override long ConvertFromString(in ReadOnlySpan<char> source, NumberFormatInfo format) =>
             long.Parse(source, provider: format);
 
         protected override string ConvertToString(long value, NumberFormatInfo format) =>

--- a/src/FluentFiles.Converters/SingleConverter.cs
+++ b/src/FluentFiles.Converters/SingleConverter.cs
@@ -6,7 +6,7 @@ namespace FluentFiles.Converters
 {
     public sealed class SingleConverter : NumberConverterBase<float>
     {
-        protected override float ConvertFromString(ReadOnlySpan<char> source, NumberFormatInfo format) =>
+        protected override float ConvertFromString(in ReadOnlySpan<char> source, NumberFormatInfo format) =>
             float.Parse(source, provider: format);
 
         protected override string ConvertToString(float value, NumberFormatInfo format) =>

--- a/src/FluentFiles.Converters/StringConverter.cs
+++ b/src/FluentFiles.Converters/StringConverter.cs
@@ -1,6 +1,5 @@
 ﻿using FluentFiles.Core.Conversion;
 using System;
-using System.Reflection;
 
 namespace FluentFiles.Converters
 {
@@ -8,8 +7,8 @@ namespace FluentFiles.Converters
     {
         public bool CanConvert(Type from, Type to) => from == typeof(string) && to == typeof(string);
 
-        public object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty) => source.Length == 0 ? string.Empty : source.ToString();
+        public object ConvertFromString(in FieldDeserializationContext context) => context.Source.Length == 0 ? string.Empty : context.Source.ToString();
 
-        public string ConvertToString(object source, PropertyInfo sourceProperty) => ((string)source);
+        public string ConvertToString(in FieldSerializationContext context) => (string)context.Source;
     }
 }

--- a/src/FluentFiles.Core/Base/LineBuilderBase.cs
+++ b/src/FluentFiles.Core/Base/LineBuilderBase.cs
@@ -1,3 +1,5 @@
+using FluentFiles.Core.Conversion;
+
 namespace FluentFiles.Core.Base
 {
     public abstract class LineBuilderBase<TLayoutDescriptor, TFieldSettings> : ILineBuilder
@@ -30,7 +32,7 @@ namespace FluentFiles.Core.Base
         {
             var converter = field.Converter;
             if (converter != null && converter.CanConvert(from: field.Type, to: typeof(string)))
-                return converter.ConvertToString(fieldValue, field.PropertyInfo);
+                return converter.ConvertToString(new FieldSerializationContext(fieldValue, field.PropertyInfo));
 
             return fieldValue.ToString();
         }

--- a/src/FluentFiles.Core/Base/LineParserBase.cs
+++ b/src/FluentFiles.Core/Base/LineParserBase.cs
@@ -1,5 +1,6 @@
 namespace FluentFiles.Core.Base
 {
+    using FluentFiles.Core.Conversion;
     using System;
 
     public abstract class LineParserBase<TLayoutDescriptor, TFieldSettings> : ILineParser
@@ -34,7 +35,7 @@ namespace FluentFiles.Core.Base
         {
             var converter = field.Converter;
             if (converter != null && converter.CanConvert(from: typeof(string), to: field.Type))
-                return converter.ConvertFromString(source, field.PropertyInfo);
+                return converter.ConvertFromString(new FieldDeserializationContext(source, field.PropertyInfo));
 
             return null;
         }

--- a/src/FluentFiles.Core/Conversion/ConverterBase.cs
+++ b/src/FluentFiles.Core/Conversion/ConverterBase.cs
@@ -13,12 +13,41 @@ namespace FluentFiles.Core.Conversion
             (from == typeof(string) && to == typeof(TValue)) || 
             (from == typeof(TValue) && to == typeof(string));
 
-        public object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty) => ConvertFrom(source, targetProperty);
+        public object ConvertFromString(in FieldDeserializationContext context) =>
+            ConvertFrom(context);
 
-        public string ConvertToString(object source, PropertyInfo sourceProperty) => ConvertTo((TValue)source, sourceProperty);
+        public string ConvertToString(in FieldSerializationContext context) =>
+            ConvertTo(new FieldSerializationContext<TValue>((TValue)context.Source, context.SourceProperty));
 
-        protected abstract TValue ConvertFrom(ReadOnlySpan<char> source, PropertyInfo targetProperty);
+        protected abstract TValue ConvertFrom(in FieldDeserializationContext context);
 
-        protected abstract string ConvertTo(TValue source, PropertyInfo sourceProperty);
+        protected abstract string ConvertTo(in FieldSerializationContext<TValue> context);
+    }
+
+    /// <summary>
+    /// Provides information about a field serialization operation.
+    /// </summary>
+    public readonly ref struct FieldSerializationContext<TValue>
+    {
+        /// <summary>
+        /// Initializes a new <see cref="FieldSerializationContext"/>.
+        /// </summary>
+        /// <param name="source">The object to serialize.</param>
+        /// <param name="sourceProperty">The property the source value is from.</param>
+        public FieldSerializationContext(TValue source, PropertyInfo sourceProperty)
+        {
+            Source = source;
+            SourceProperty = sourceProperty;
+        }
+
+        /// <summary>
+        /// The object to serialize.
+        /// </summary>
+        public TValue Source { get; }
+
+        /// <summary>
+        /// The property the source value is from.
+        /// </summary>
+        public PropertyInfo SourceProperty { get; }
     }
 }

--- a/src/FluentFiles.Core/Conversion/DefaultConverter.cs
+++ b/src/FluentFiles.Core/Conversion/DefaultConverter.cs
@@ -1,6 +1,5 @@
 ﻿using FluentFiles.Core.Extensions;
 using System;
-using System.Reflection;
 
 namespace FluentFiles.Core.Conversion
 {
@@ -10,8 +9,8 @@ namespace FluentFiles.Core.Conversion
 
         public bool CanConvert(Type from, Type to) => from == typeof(string);
 
-        public object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty) => targetProperty.PropertyType.GetDefaultValue();
+        public object ConvertFromString(in FieldDeserializationContext context) => context.TargetProperty.PropertyType.GetDefaultValue();
 
-        public string ConvertToString(object source, PropertyInfo sourceProperty) => source.ToString();
+        public string ConvertToString(in FieldSerializationContext context) => context.Source.ToString();
     }
 }

--- a/src/FluentFiles.Core/Conversion/DelegatingConverter.cs
+++ b/src/FluentFiles.Core/Conversion/DelegatingConverter.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Reflection;
 
 namespace FluentFiles.Core.Conversion
 {
     /// <summary>
     /// An implementation of <see cref="IFieldValueConverter"/> that uses delegates for conversion.
     /// </summary>
-    class DelegatingConverter<TProperty> : IFieldValueConverter
+    internal class DelegatingConverter<TProperty> : IFieldValueConverter
     {
         internal ConvertFromString<TProperty> ConversionFromString { get; set; }
 
@@ -16,14 +15,14 @@ namespace FluentFiles.Core.Conversion
             (from == typeof(string) && to == typeof(TProperty) && ConversionFromString != null) ||
             (from == typeof(TProperty) && to == typeof(string) && ConversionToString != null);
 
-        public object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty)
+        public object ConvertFromString(in FieldDeserializationContext context)
         {
-            return ConversionFromString(source);
+            return ConversionFromString(context.Source);
         }
 
-        public string ConvertToString(object source, PropertyInfo sourceProperty)
+        public string ConvertToString(in FieldSerializationContext context)
         {
-            return ConversionToString((TProperty)source);
+            return ConversionToString((TProperty)context.Source);
         }
     }
 }

--- a/src/FluentFiles.Core/Conversion/FieldValueConverterAdapter.cs
+++ b/src/FluentFiles.Core/Conversion/FieldValueConverterAdapter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 
 namespace FluentFiles.Core.Conversion
 {
@@ -21,8 +20,8 @@ namespace FluentFiles.Core.Conversion
 
         public bool CanConvert(Type from, Type to) => _converter.CanConvertFrom(from) && _converter.CanConvertTo(to);
 
-        public object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty) => _converter.ConvertFromString(source.ToString());
+        public object ConvertFromString(in FieldDeserializationContext context) => _converter.ConvertFromString(context.Source.ToString());
 
-        public string ConvertToString(object source, PropertyInfo sourceProperty) => _converter.ConvertToString(source);
+        public string ConvertToString(in FieldSerializationContext context) => _converter.ConvertToString(context.Source);
     }
 }

--- a/src/FluentFiles.Core/Conversion/IFieldValueConverter.cs
+++ b/src/FluentFiles.Core/Conversion/IFieldValueConverter.cs
@@ -6,7 +6,7 @@ namespace FluentFiles.Core.Conversion
     /// <summary>
     /// Defines a way to convert a field's string value to and from a custom type.
     /// </summary>
-    public interface IFieldValueConverter
+    public interface IFieldValueConverter : IFieldSerializer, IFieldDeserializer
     {
         /// <summary>
         /// Whether a value of a given type can be converted to another type.
@@ -15,21 +15,85 @@ namespace FluentFiles.Core.Conversion
         /// <param name="to">The type t oconvert to.</param>
         /// <returns>Whether a conversion can be performed between the two types.</returns>
         bool CanConvert(Type from, Type to);
+    }
 
+    /// <summary>
+    /// Defines a way to convert a field's value to a string.
+    /// </summary>
+    public interface IFieldSerializer
+    {
         /// <summary>
         /// Converts an object to a string.
         /// </summary>
-        /// <param name="source">The object to serialize.</param>
-        /// <param name="sourceProperty">The property the object value is from.</param>
-        /// <returns>A serialized version of <paramref name="source"/>.</returns>
-        string ConvertToString(object source, PropertyInfo sourceProperty);
+        /// <param name="context">Provides information about a field serialization operation.</param>
+        /// <returns>A serialized value.</returns>
+        string ConvertToString(in FieldSerializationContext context);
+    }
 
+    /// <summary>
+    /// Defines a way to convert a string to a field's target type.
+    /// </summary>
+    public interface IFieldDeserializer
+    {
         /// <summary>
         /// Converts a string to an object instance.
         /// </summary>
+        /// <param name="context">Provides information about a field deserialization operation.</param>
+        /// <returns>A deserialized value.</returns>
+        object ConvertFromString(in FieldDeserializationContext context);
+    }
+
+    /// <summary>
+    /// Provides information about a field serialization operation.
+    /// </summary>
+    public readonly ref struct FieldSerializationContext
+    {
+        /// <summary>
+        /// Initializes a new <see cref="FieldSerializationContext"/>.
+        /// </summary>
+        /// <param name="source">The object to serialize.</param>
+        /// <param name="sourceProperty">The property the source value is from.</param>
+        public FieldSerializationContext(object source, PropertyInfo sourceProperty)
+        {
+            Source = source;
+            SourceProperty = sourceProperty;
+        }
+
+        /// <summary>
+        /// The object to serialize.
+        /// </summary>
+        public object Source { get; }
+
+        /// <summary>
+        /// The property the source value is from.
+        /// </summary>
+        public PropertyInfo SourceProperty { get; }
+    }
+
+    /// <summary>
+    /// Provides information about a field deserialization operation.
+    /// </summary>
+    public readonly ref struct FieldDeserializationContext
+    {
+        /// <summary>
+        /// Initializes a new <see cref="FieldDeserializationContext"/>.
+        /// </summary>
         /// <param name="source">The string to deserialize.</param>
-        /// <param name="targetProperty">The property the object value should be assigned to.</param>
-        /// <returns>A deserialized version of <paramref name="source"/>.</returns>
-        object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty);
+        /// <param name="targetProperty">The property the deserialized source value should be assigned to.</param>
+        public FieldDeserializationContext(in ReadOnlySpan<char> source, PropertyInfo targetProperty)
+        {
+            Source = source;
+            TargetProperty = targetProperty;
+        }
+
+        /// <summary>
+        /// The string to deserialize.
+        /// </summary>
+        public ReadOnlySpan<char> Source { get; }
+
+        /// <summary>
+        /// The property the deserialized source value should be assigned to.
+        /// </summary>
+        public PropertyInfo TargetProperty { get; }
     }
 }

--- a/src/FluentFiles.Core/Conversion/NumberConverterBase.cs
+++ b/src/FluentFiles.Core/Conversion/NumberConverterBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Globalization;
-using System.Reflection;
 
 namespace FluentFiles.Core.Conversion
 {
@@ -11,9 +10,11 @@ namespace FluentFiles.Core.Conversion
     /// </summary>
     public abstract class NumberConverterBase<T> : IFieldValueConverter
     {
+        internal NumberConverterBase() { }
+
         protected Type TargetType { get; } = typeof(T);
 
-        protected abstract T ConvertFromString(ReadOnlySpan<char> source, NumberFormatInfo format);
+        protected abstract T ConvertFromString(in ReadOnlySpan<char> source, NumberFormatInfo format);
 
         protected abstract string ConvertToString(T value, NumberFormatInfo format);
 
@@ -21,18 +22,18 @@ namespace FluentFiles.Core.Conversion
             (from == typeof(string) && to == TargetType) ||
             (from == TargetType && to == typeof(string));
 
-        public object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty)
+        public object ConvertFromString(in FieldDeserializationContext context)
         {
             var culture = CultureInfo.CurrentCulture;
             var numberFormat = (NumberFormatInfo)culture.GetFormat(typeof(NumberFormatInfo));
-            return ConvertFromString(source.Trim(), numberFormat);
+            return ConvertFromString(context.Source.Trim(), numberFormat);
         }
 
-        public string ConvertToString(object source, PropertyInfo sourceProperty)
+        public string ConvertToString(in FieldSerializationContext context)
         {
             var culture = CultureInfo.CurrentCulture;
             var numberFormat = (NumberFormatInfo)culture.GetFormat(typeof(NumberFormatInfo));
-            return ConvertToString((T)source, numberFormat);
+            return ConvertToString((T)context.Source, numberFormat);
         }
     }
 }

--- a/src/FluentFiles.Core/Conversion/TypeConverterAdapter.cs
+++ b/src/FluentFiles.Core/Conversion/TypeConverterAdapter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Reflection;
 
 namespace FluentFiles.Core.Conversion
 {
@@ -22,9 +21,9 @@ namespace FluentFiles.Core.Conversion
 
         public bool CanConvert(Type from, Type to) => _converter.CanConvertFrom(from) && (OverrideCanConvertTo || _converter.CanConvertTo(to));
 
-        public object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty) => _converter.ConvertFromString(source.ToString());
+        public object ConvertFromString(in FieldDeserializationContext context) => _converter.ConvertFromString(context.Source.ToString());
 
-        public string ConvertToString(object source, PropertyInfo sourceProperty) => _converter.ConvertToString(source);
+        public string ConvertToString(in FieldSerializationContext context) => _converter.ConvertToString(context.Source);
 
         /// <summary>
         /// Some built-in <see cref="TypeConverter"/>s don't return as expected for <see cref="TypeConverter.CanConvertTo(Type)"/>.

--- a/src/FluentFiles.Core/Properties/AssemblyInfo.cs
+++ b/src/FluentFiles.Core/Properties/AssemblyInfo.cs
@@ -6,3 +6,4 @@
 [assembly: InternalsVisibleTo("FluentFiles.Delimited.Attributes")]
 [assembly: InternalsVisibleTo("FluentFiles.Delimited")]
 [assembly: InternalsVisibleTo("FluentFiles.Core.Attributes")]
+[assembly: InternalsVisibleTo("FluentFiles.Converters")]

--- a/src/FluentFiles.Tests/Conversion/ByteConverterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/ByteConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentFiles.Converters;
+using FluentFiles.Core.Conversion;
 using Xunit;
 
 namespace FluentFiles.Tests.Conversion
@@ -15,7 +16,7 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertFromString(string input, byte expected)
         {
             // Act.
-            var actual = _converter.ConvertFromString(input, null);
+            var actual = _converter.ConvertFromString(new FieldDeserializationContext(input, null));
 
             // Assert.
             Assert.Equal(expected, actual);
@@ -29,10 +30,10 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertToString(byte input, string expected)
         {
             // Act.
-            var actual = _converter.ConvertToString(input, null);
+            var actual = _converter.ConvertToString(new FieldSerializationContext(input, null));
 
             // Assert.
-            Assert.Equal(expected, actual.ToString());
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Conversion/CharConverterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/CharConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentFiles.Converters;
+using FluentFiles.Core.Conversion;
 using Xunit;
 
 namespace FluentFiles.Tests.Conversion
@@ -18,7 +19,7 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertFromString(string input, char expected)
         {
             // Act.
-            var actual = _converter.ConvertFromString(input, null);
+            var actual = _converter.ConvertFromString(new FieldDeserializationContext(input, null));
 
             // Assert.
             Assert.Equal(expected, actual);
@@ -32,10 +33,10 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertToString(char input, string expected)
         {
             // Act.
-            var actual = _converter.ConvertToString(input, null);
+            var actual = _converter.ConvertToString(new FieldSerializationContext(input, null));
 
             // Assert.
-            Assert.Equal(expected, actual.ToString());
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Conversion/DecimalConverterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/DecimalConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentFiles.Converters;
+using FluentFiles.Core.Conversion;
 using System.Collections.Generic;
 using Xunit;
 
@@ -23,7 +24,7 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertFromString(string input, decimal expected)
         {
             // Act.
-            var actual = _converter.ConvertFromString(input, null);
+            var actual = _converter.ConvertFromString(new FieldDeserializationContext(input, null));
 
             // Assert.
             Assert.Equal(expected, actual);
@@ -44,10 +45,10 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertToString(decimal input, string expected)
         {
             // Act.
-            var actual = _converter.ConvertToString(input, null);
+            var actual = _converter.ConvertToString(new FieldSerializationContext(input, null));
 
             // Assert.
-            Assert.Equal(expected, actual.ToString());
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Conversion/DoubleConverterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/DoubleConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentFiles.Converters;
+using FluentFiles.Core.Conversion;
 using Xunit;
 
 namespace FluentFiles.Tests.Conversion
@@ -16,7 +17,7 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertFromString(string input, double expected)
         {
             // Act.
-            var actual = _converter.ConvertFromString(input, null);
+            var actual = _converter.ConvertFromString(new FieldDeserializationContext(input, null));
 
             // Assert.
             Assert.Equal(expected, actual);
@@ -31,10 +32,10 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertToString(double input, string expected)
         {
             // Act.
-            var actual = _converter.ConvertToString(input, null);
+            var actual = _converter.ConvertToString(new FieldSerializationContext(input, null));
 
             // Assert.
-            Assert.Equal(expected, actual.ToString());
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Conversion/GuidConverterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/GuidConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentFiles.Converters;
+using FluentFiles.Core.Conversion;
 using System;
 using Xunit;
 
@@ -18,7 +19,7 @@ namespace FluentFiles.Tests.Conversion
             var expected = Guid.Parse(input);
 
             // Act.
-            var actual = _converter.ConvertFromString(input, null);
+            var actual = _converter.ConvertFromString(new FieldDeserializationContext(input, null));
 
             // Assert.
             Assert.Equal(expected, actual);
@@ -34,10 +35,10 @@ namespace FluentFiles.Tests.Conversion
             var guid = Guid.Parse(input);
 
             // Act.
-            var actual = _converter.ConvertToString(guid, null);
+            var actual = _converter.ConvertToString(new FieldSerializationContext(guid, null));
 
             // Assert.
-            Assert.Equal(expected, actual.ToString());
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Conversion/Int16ConverterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/Int16ConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentFiles.Converters;
+using FluentFiles.Core.Conversion;
 using Xunit;
 
 namespace FluentFiles.Tests.Conversion
@@ -16,7 +17,7 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertFromString(string input, short expected)
         {
             // Act.
-            var actual = _converter.ConvertFromString(input, null);
+            var actual = _converter.ConvertFromString(new FieldDeserializationContext(input, null));
 
             // Assert.
             Assert.Equal(expected, actual);
@@ -31,10 +32,10 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertToString(short input, string expected)
         {
             // Act.
-            var actual = _converter.ConvertToString(input, null);
+            var actual = _converter.ConvertToString(new FieldSerializationContext(input, null));
 
             // Assert.
-            Assert.Equal(expected, actual.ToString());
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Conversion/Int32ConverterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/Int32ConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentFiles.Converters;
+using FluentFiles.Core.Conversion;
 using Xunit;
 
 namespace FluentFiles.Tests.Conversion
@@ -16,7 +17,7 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertFromString(string input, int expected)
         {
             // Act.
-            var actual = _converter.ConvertFromString(input, null);
+            var actual = _converter.ConvertFromString(new FieldDeserializationContext(input, null));
 
             // Assert.
             Assert.Equal(expected, actual);
@@ -31,10 +32,10 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertToString(int input, string expected)
         {
             // Act.
-            var actual = _converter.ConvertToString(input, null);
+            var actual = _converter.ConvertToString(new FieldSerializationContext(input, null));
 
             // Assert.
-            Assert.Equal(expected, actual.ToString());
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Conversion/Int64ConverterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/Int64ConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentFiles.Converters;
+using FluentFiles.Core.Conversion;
 using Xunit;
 
 namespace FluentFiles.Tests.Conversion
@@ -16,7 +17,7 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertFromString(string input, long expected)
         {
             // Act.
-            var actual = _converter.ConvertFromString(input, null);
+            var actual = _converter.ConvertFromString(new FieldDeserializationContext(input, null));
 
             // Assert.
             Assert.Equal(expected, actual);
@@ -31,10 +32,10 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertToString(long input, string expected)
         {
             // Act.
-            var actual = _converter.ConvertToString(input, null);
+            var actual = _converter.ConvertToString(new FieldSerializationContext(input, null));
 
             // Assert.
-            Assert.Equal(expected, actual.ToString());
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Conversion/SingleConverterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/SingleConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentFiles.Converters;
+using FluentFiles.Core.Conversion;
 using Xunit;
 
 namespace FluentFiles.Tests.Conversion
@@ -16,7 +17,7 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertFromString(string input, float expected)
         {
             // Act.
-            var actual = _converter.ConvertFromString(input, null);
+            var actual = _converter.ConvertFromString(new FieldDeserializationContext(input, null));
 
             // Assert.
             Assert.Equal(expected, actual);
@@ -31,10 +32,10 @@ namespace FluentFiles.Tests.Conversion
         public void Test_ConvertToString(float input, string expected)
         {
             // Act.
-            var actual = _converter.ConvertToString(input, null);
+            var actual = _converter.ConvertToString(new FieldSerializationContext(input, null));
 
             // Assert.
-            Assert.Equal(expected, actual.ToString());
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Conversion/TypeConverterAdapterTests.cs
+++ b/src/FluentFiles.Tests/Conversion/TypeConverterAdapterTests.cs
@@ -30,7 +30,7 @@ namespace FluentFiles.Tests.Conversion
             var adapter = new TypeConverterAdapter(adapted);
 
             // Act.
-            var actual = adapter.ConvertFromString("1", null);
+            var actual = adapter.ConvertFromString(new FieldDeserializationContext("1", null));
 
             // Assert.
             Assert.Equal(1, actual);
@@ -45,10 +45,10 @@ namespace FluentFiles.Tests.Conversion
             var adapter = new TypeConverterAdapter(adapted);
 
             // Act.
-            var actual = adapter.ConvertToString(1, null);
+            var actual = adapter.ConvertToString(new FieldSerializationContext(1, null));
 
             // Assert.
-            Assert.Equal("1", actual.ToString());
+            Assert.Equal("1", actual);
         }
     }
 }

--- a/src/FluentFiles.Tests/Delimited/DelimitedAttributeMappingIntegrationTests.cs
+++ b/src/FluentFiles.Tests/Delimited/DelimitedAttributeMappingIntegrationTests.cs
@@ -36,8 +36,8 @@ namespace FluentFiles.Tests.Delimited
         class StubConverter : IFieldValueConverter
         {
             public bool CanConvert(Type from, Type to) => true;
-            public object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty) => "foo";
-            public string ConvertToString(object source, PropertyInfo sourceProperty) => source.ToString();
+            public object ConvertFromString(in FieldDeserializationContext context) => "foo";
+            public string ConvertToString(in FieldSerializationContext context) => context.Source.ToString();
         }
 
         [Fact]

--- a/src/FluentFiles.Tests/Delimited/DelimitedLineBuilderTests.cs
+++ b/src/FluentFiles.Tests/Delimited/DelimitedLineBuilderTests.cs
@@ -71,14 +71,14 @@ namespace FluentFiles.Tests.Delimited
 
         class IdHexConverter : ConverterBase<int>
         {
-            protected override int ConvertFrom(ReadOnlySpan<char> source, PropertyInfo targetProperty)
+            protected override int ConvertFrom(in FieldDeserializationContext context)
             {
-                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+                return Int32.Parse(context.Source, NumberStyles.AllowHexSpecifier);
             }
 
-            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            protected override string ConvertTo(in FieldSerializationContext<int> context)
             {
-                return source.ToString("X");
+                return context.Source.ToString("X");
             }
         }
     }

--- a/src/FluentFiles.Tests/Delimited/DelimitedLineParserTests.cs
+++ b/src/FluentFiles.Tests/Delimited/DelimitedLineParserTests.cs
@@ -81,14 +81,14 @@ namespace FluentFiles.Tests.Delimited
 
         class IdHexConverter : ConverterBase<int>
         {
-            protected override int ConvertFrom(ReadOnlySpan<char> source, PropertyInfo targetProperty)
+            protected override int ConvertFrom(in FieldDeserializationContext context)
             {
-                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+                return Int32.Parse(context.Source, NumberStyles.AllowHexSpecifier);
             }
 
-            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            protected override string ConvertTo(in FieldSerializationContext<int> context)
             {
-                return source.ToString("X");
+                return context.Source.ToString("X");
             }
         }
 

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthAttributeMappingIntegrationTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthAttributeMappingIntegrationTests.cs
@@ -27,8 +27,8 @@ namespace FluentFiles.Tests.FixedLength
         class StubConverter : IFieldValueConverter
         {
             public bool CanConvert(Type from, Type to) => true;
-            public object ConvertFromString(ReadOnlySpan<char> source, PropertyInfo targetProperty) => "foo";
-            public string ConvertToString(object source, PropertyInfo sourceProperty) => source.ToString();
+            public object ConvertFromString(in FieldDeserializationContext context) => "foo";
+            public string ConvertToString(in FieldSerializationContext context) => context.Source.ToString();
         }
 
         public FixedLengthAttributeMappingIntegrationTests()

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthLineBuilderTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthLineBuilderTests.cs
@@ -71,14 +71,14 @@ namespace FluentFiles.Tests.FixedLength
 
         class IdHexConverter : ConverterBase<int>
         {
-            protected override int ConvertFrom(ReadOnlySpan<char> source, PropertyInfo targetProperty)
+            protected override int ConvertFrom(in FieldDeserializationContext context)
             {
-                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+                return Int32.Parse(context.Source, NumberStyles.AllowHexSpecifier);
             }
 
-            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            protected override string ConvertTo(in FieldSerializationContext<int> context)
             {
-                return source.ToString("X");
+                return context.Source.ToString("X");
             }
         }
     }

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthLineParserTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthLineParserTests.cs
@@ -181,14 +181,14 @@ namespace FluentFiles.Tests.FixedLength
 
         class IdHexConverter : ConverterBase<int>
         {
-            protected override int ConvertFrom(ReadOnlySpan<char> source, PropertyInfo targetProperty)
+            protected override int ConvertFrom(in FieldDeserializationContext context)
             {
-                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+                return Int32.Parse(context.Source, NumberStyles.AllowHexSpecifier);
             }
 
-            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            protected override string ConvertTo(in FieldSerializationContext<int> context)
             {
-                return source.ToString("X");
+                return context.Source.ToString("X");
             }
         }
 


### PR DESCRIPTION
Incorporate parameters to conversion methods into a context object. This will help to reduce the impact of any future parameter additions.