### PR TITLE
Implement writing ignored fields

### DIFF
--- a/src/FluentFiles.Core/IFieldSettingsBuilder.cs
+++ b/src/FluentFiles.Core/IFieldSettingsBuilder.cs
@@ -1,10 +1,10 @@
 ﻿namespace FluentFiles.Core
 {
-    using FluentFiles.Core.Conversion;
     using System;
+    using FluentFiles.Core.Conversion;
 
     /// <summary>
-    /// A builder that can configure and produce a mapping configuration for a fixed-length field.
+    /// A builder that can configure and produce a mapping configuration for a field.
     /// </summary>
     /// <typeparam name="TBuilder">The self-referencing type of a builder.</typeparam>
     /// <typeparam name="TSettings">The type of field mapping being configured.</typeparam>

--- a/src/FluentFiles.FixedLength.Attributes/IgnoreFixedLengthFieldAttribute.cs
+++ b/src/FluentFiles.FixedLength.Attributes/IgnoreFixedLengthFieldAttribute.cs
@@ -19,6 +19,11 @@
         public int Length { get; }
 
         /// <summary>
+        /// The character to fill an ignored field with when writing.
+        /// </summary>
+        public char Filler { get; set; } = ' ';
+
+        /// <summary>
         /// Initializes a new <see cref="IgnoreFixedLengthFieldAttribute"/>.
         /// </summary>
         /// <param name="index">Where in a line the ignored section begins.</param>

--- a/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
+++ b/src/FluentFiles.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
@@ -28,7 +28,7 @@ namespace FluentFiles.FixedLength.Attributes.Infrastructure
 
             foreach (var ignored in fileMappingType.GetAttributes<IgnoreFixedLengthFieldAttribute>())
             {
-                container.AddOrUpdate(new IgnoredFixedFieldSettings(ignored.Length) { Index = ignored.Index });
+                container.AddOrUpdate(new IgnoredFixedFieldSettings(ignored.Length, ignored.Filler) { Index = ignored.Index });
             }
 
             var members = fileMappingType.GetTypeDescription<FixedLengthFieldAttribute>();

--- a/src/FluentFiles.FixedLength/IFixedLayout.cs
+++ b/src/FluentFiles.FixedLength/IFixedLayout.cs
@@ -1,5 +1,6 @@
 ﻿namespace FluentFiles.FixedLength
 {
+    using System;
     using FluentFiles.Core;
 
     /// <summary>
@@ -11,9 +12,23 @@
         ILayout<TTarget, IFixedFieldSettingsContainer, IFixedFieldSettingsBuilder, IFixedLayout<TTarget>>
     {
         /// <summary>
-        /// Ignores a fixed width section of a record.
+        /// Ignores a fixed width section of a record. When writing, the field will be filled with spaces
+        /// by default, or an alternate character can be chosen using the configuration action.
         /// </summary>
         /// <param name="length">The length of the section to ignore.</param>
-        IFixedLayout<TTarget> Ignore(int length);
+        /// <param name="configure">An action that can be used to further configure the ignored field.</param>
+        IFixedLayout<TTarget> Ignore(int length, Action<IIgnoredFieldBuilder>? configure = null);
+    }
+
+    /// <summary>
+    /// Provides configuration for an ignored field.
+    /// </summary>
+    public interface IIgnoredFieldBuilder
+    {
+        /// <summary>
+        /// Specifies that on write, an ignored field will have the given character repeated for the length of the field.
+        /// </summary>
+        /// <param name="filler">The character to fill an ignored field with when writing.</param>
+        public IIgnoredFieldBuilder FillWith(char filler);
     }
 }

--- a/src/FluentFiles.FixedLength/Implementation/FixedLayout.cs
+++ b/src/FluentFiles.FixedLength/Implementation/FixedLayout.cs
@@ -61,13 +61,29 @@ namespace FluentFiles.FixedLength.Implementation
         }
 
         /// <summary>
-        /// Ignores a fixed width section of a record.
+        /// Ignores a fixed width section of a record. When writing, the field will be filled with spaces
+        /// by default, or an alternate character can be chosen using the configuration action.
         /// </summary>
         /// <param name="length">The length of the section to ignore.</param>
-        public IFixedLayout<TTarget> Ignore(int length)
+        /// <param name="configure">An action that can be used to further configure the ignored field.</param>
+        public IFixedLayout<TTarget> Ignore(int length, Action<IIgnoredFieldBuilder>? configure)
         {
-            FieldCollection.AddOrUpdate(new IgnoredFixedFieldSettings(length));
+            var builder = new IgnoredFieldBuilder();
+            configure?.Invoke(builder);
+
+            FieldCollection.AddOrUpdate(new IgnoredFixedFieldSettings(length, builder.Filler));
             return this;
+        }
+
+        private class IgnoredFieldBuilder : IIgnoredFieldBuilder
+        {
+            public char Filler { get; private set; } = ' ';
+
+            public IIgnoredFieldBuilder FillWith(char filler)
+            {
+                Filler = filler;
+                return this;
+            }
         }
     }
 }

--- a/src/FluentFiles.FixedLength/Implementation/IgnoredFixedFieldSettings.cs
+++ b/src/FluentFiles.FixedLength/Implementation/IgnoredFixedFieldSettings.cs
@@ -6,9 +6,12 @@
 
     internal class IgnoredFixedFieldSettings : IFixedFieldSettingsContainer
     {
-        public IgnoredFixedFieldSettings(int length)
+        private readonly char _filler;
+
+        public IgnoredFixedFieldSettings(int length, char filler)
         {
             Length = length;
+            _filler = filler;
             UniqueKey = Guid.NewGuid().ToString();
         }
         
@@ -30,7 +33,7 @@
         public Type Type { get; } = typeof(string);
         public MemberInfo Member => throw new NotSupportedException("Ignored fields have no member mapped.");
 
-        public object? GetValueOf(object instance) => throw new NotSupportedException("Cannot use a fixed width layout with an ignored section for writing.");
+        public object? GetValueOf(object instance) => new string(_filler, Length);
         public void SetValueOf(object instance, object? value) { /* no-op */ }
     }
 }

--- a/src/FluentFiles.Tests/FixedLength/FixedLengthLineBuilderTests.cs
+++ b/src/FluentFiles.Tests/FixedLength/FixedLengthLineBuilderTests.cs
@@ -1,14 +1,14 @@
 namespace FluentFiles.Tests.FixedLength
 {
+    using System;
+    using System.Globalization;
+    using Xunit;
     using FluentAssertions;
     using FluentFiles.Core.Conversion;
     using FluentFiles.FixedLength;
     using FluentFiles.FixedLength.Implementation;
     using FluentFiles.Tests.Base.Entities;
-    using System;
-    using System.Globalization;
-    using Xunit;
-
+    
     public class FixedLengthLineBuilderTests
     {
         private readonly FixedLengthLineBuilder builder;
@@ -66,6 +66,30 @@ namespace FluentFiles.Tests.FixedLength
             var line = builder.BuildLine(entry);
 
             line.Should().Be("BEEF");
+        }
+
+        [Fact]
+        public void BuilderShouldFillIgnoredFieldWithSpacesByDefault()
+        {
+            layout.Ignore(5);
+
+            var entry = new TestObject();
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("     ");
+        }
+
+        [Fact]
+        public void BuilderShouldFillIgnoredFieldWithSelectedCharacter()
+        {
+            layout.Ignore(4, c => c.FillWith('0'));
+
+            var entry = new TestObject();
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("0000");
         }
 
         class IdHexConverter : ConverterBase<int>


### PR DESCRIPTION
Ignored fields can be written now. They will be filled with spaces by default, or a different character can be configured.

Fixes #35.